### PR TITLE
chore: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - run: npm ci
       - run: npm test
 
@@ -17,7 +17,7 @@ jobs:
   ubuntu-action-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - uses: ./
         with:
           name: "unbuntu unit tests"
@@ -27,7 +27,7 @@ jobs:
   macos-action-tests:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - uses: ./
         with:
           name: "macos unit tests"


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions to immutable commit SHAs instead of mutable tags
- Prevents supply chain attacks where a compromised tag could inject malicious code
- Dependabot will keep pinned SHAs up to date automatically

## Test plan
- [ ] Verify CI passes with pinned actions